### PR TITLE
Add card image attachment feature for user photos of real cards

### DIFF
--- a/Inkwell Keeper/Components/CardImageAttachmentView.swift
+++ b/Inkwell Keeper/Components/CardImageAttachmentView.swift
@@ -1,0 +1,297 @@
+//
+//  CardImageAttachmentView.swift
+//  Inkwell Keeper
+//
+
+import SwiftUI
+import PhotosUI
+
+struct CardImageAttachmentView: View {
+    let collectedCard: CollectedCard
+    @EnvironmentObject var collectionManager: CollectionManager
+    @State private var attachments: [CardImageAttachment] = []
+    @State private var selectedPhotoItem: PhotosPickerItem?
+    @State private var showingImageSource = false
+    @State private var showingCamera = false
+    @State private var showingFullscreenImage: CardImageAttachment?
+    @State private var attachmentToDelete: CardImageAttachment?
+
+    private let imageStorage = CardImageStorageService.shared
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Text("My Card Photos")
+                    .font(.headline)
+                    .foregroundColor(.lorcanaGold)
+                Spacer()
+                addPhotoButton
+            }
+
+            if attachments.isEmpty {
+                emptyState
+            } else {
+                imageGrid
+            }
+        }
+        .onAppear {
+            loadAttachments()
+        }
+        .confirmationDialog("Add Photo", isPresented: $showingImageSource) {
+            Button("Take Photo") { showingCamera = true }
+            Button("Choose from Library") { } // Handled by PhotosPicker overlay below
+            Button("Cancel", role: .cancel) { }
+        }
+        .fullScreenCover(item: $showingFullscreenImage) { attachment in
+            FullscreenAttachmentViewer(
+                attachment: attachment,
+                onDelete: {
+                    removeAttachment(attachment)
+                    showingFullscreenImage = nil
+                }
+            )
+        }
+        .fullScreenCover(isPresented: $showingCamera) {
+            CameraCaptureView { image in
+                addImage(image)
+            }
+        }
+        .alert("Delete Photo", isPresented: Binding(
+            get: { attachmentToDelete != nil },
+            set: { if !$0 { attachmentToDelete = nil } }
+        )) {
+            Button("Cancel", role: .cancel) { attachmentToDelete = nil }
+            Button("Delete", role: .destructive) {
+                if let attachment = attachmentToDelete {
+                    removeAttachment(attachment)
+                    attachmentToDelete = nil
+                }
+            }
+        } message: {
+            Text("Are you sure you want to delete this photo?")
+        }
+    }
+
+    private var addPhotoButton: some View {
+        Menu {
+            Button(action: { showingCamera = true }) {
+                Label("Take Photo", systemImage: "camera")
+            }
+            PhotosPicker(selection: $selectedPhotoItem, matching: .images) {
+                Label("Choose from Library", systemImage: "photo.on.rectangle")
+            }
+        } label: {
+            Image(systemName: "plus.circle.fill")
+                .font(.title3)
+                .foregroundColor(.lorcanaGold)
+        }
+        .onChange(of: selectedPhotoItem) { newItem in
+            guard let newItem else { return }
+            Task {
+                if let data = try? await newItem.loadTransferable(type: Data.self),
+                   let image = UIImage(data: data) {
+                    await MainActor.run {
+                        addImage(image)
+                    }
+                }
+                selectedPhotoItem = nil
+            }
+        }
+    }
+
+    private var emptyState: some View {
+        HStack {
+            Spacer()
+            VStack(spacing: 8) {
+                Image(systemName: "camera.badge.ellipsis")
+                    .font(.title2)
+                    .foregroundColor(.gray)
+                Text("No photos yet")
+                    .font(.caption)
+                    .foregroundColor(.gray)
+                Text("Add photos of your real card")
+                    .font(.caption2)
+                    .foregroundColor(.gray.opacity(0.7))
+            }
+            .padding(.vertical, 16)
+            Spacer()
+        }
+    }
+
+    private var imageGrid: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 10) {
+                ForEach(attachments, id: \.id) { attachment in
+                    attachmentThumbnail(attachment)
+                }
+            }
+        }
+    }
+
+    private func attachmentThumbnail(_ attachment: CardImageAttachment) -> some View {
+        Group {
+            if let image = imageStorage.loadImage(fileName: attachment.fileName) {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fill)
+                    .frame(width: 90, height: 126)
+                    .clipShape(RoundedRectangle(cornerRadius: 8))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 8)
+                            .stroke(Color.lorcanaGold.opacity(0.3), lineWidth: 1)
+                    )
+                    .onTapGesture {
+                        showingFullscreenImage = attachment
+                    }
+                    .contextMenu {
+                        Button(role: .destructive) {
+                            attachmentToDelete = attachment
+                        } label: {
+                            Label("Delete", systemImage: "trash")
+                        }
+                    }
+            } else {
+                RoundedRectangle(cornerRadius: 8)
+                    .fill(Color.gray.opacity(0.3))
+                    .frame(width: 90, height: 126)
+                    .overlay(
+                        Image(systemName: "exclamationmark.triangle")
+                            .foregroundColor(.gray)
+                    )
+            }
+        }
+    }
+
+    private func addImage(_ image: UIImage) {
+        if let attachment = collectionManager.addImageAttachment(to: collectedCard, image: image) {
+            withAnimation {
+                attachments.append(attachment)
+            }
+        }
+    }
+
+    private func removeAttachment(_ attachment: CardImageAttachment) {
+        collectionManager.removeImageAttachment(attachment)
+        withAnimation {
+            attachments.removeAll { $0.id == attachment.id }
+        }
+    }
+
+    private func loadAttachments() {
+        attachments = collectionManager.getImageAttachments(for: collectedCard)
+    }
+}
+
+// MARK: - Fullscreen Attachment Viewer
+
+struct FullscreenAttachmentViewer: View {
+    let attachment: CardImageAttachment
+    let onDelete: () -> Void
+    @Environment(\.dismiss) private var dismiss
+    @State private var scale: CGFloat = 1.0
+    @State private var lastScale: CGFloat = 1.0
+
+    private let imageStorage = CardImageStorageService.shared
+
+    var body: some View {
+        ZStack {
+            Color.black.ignoresSafeArea()
+
+            if let image = imageStorage.loadImage(fileName: attachment.fileName) {
+                Image(uiImage: image)
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .scaleEffect(scale)
+                    .gesture(
+                        MagnifyGesture()
+                            .onChanged { value in
+                                scale = lastScale * value.magnification
+                            }
+                            .onEnded { _ in
+                                lastScale = scale
+                                if scale < 1.0 {
+                                    withAnimation { scale = 1.0 }
+                                    lastScale = 1.0
+                                }
+                            }
+                    )
+                    .onTapGesture(count: 2) {
+                        withAnimation {
+                            if scale > 1.0 {
+                                scale = 1.0
+                                lastScale = 1.0
+                            } else {
+                                scale = 2.5
+                                lastScale = 2.5
+                            }
+                        }
+                    }
+            }
+
+            VStack {
+                HStack {
+                    Button(action: { dismiss() }) {
+                        Image(systemName: "xmark.circle.fill")
+                            .font(.title)
+                            .foregroundColor(.white)
+                    }
+                    Spacer()
+                    Button(role: .destructive, action: onDelete) {
+                        Image(systemName: "trash.circle.fill")
+                            .font(.title)
+                            .foregroundColor(.red)
+                    }
+                }
+                .padding()
+                Spacer()
+
+                Text(attachment.dateAdded, style: .date)
+                    .font(.caption)
+                    .foregroundColor(.white.opacity(0.6))
+                    .padding(.bottom, 8)
+            }
+        }
+    }
+}
+
+// MARK: - Camera Capture View
+
+struct CameraCaptureView: UIViewControllerRepresentable {
+    let onCapture: (UIImage) -> Void
+    @Environment(\.dismiss) private var dismiss
+
+    func makeUIViewController(context: Context) -> UIImagePickerController {
+        let picker = UIImagePickerController()
+        picker.sourceType = .camera
+        picker.delegate = context.coordinator
+        return picker
+    }
+
+    func updateUIViewController(_ uiViewController: UIImagePickerController, context: Context) {}
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(onCapture: onCapture, dismiss: dismiss)
+    }
+
+    class Coordinator: NSObject, UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+        let onCapture: (UIImage) -> Void
+        let dismiss: DismissAction
+
+        init(onCapture: @escaping (UIImage) -> Void, dismiss: DismissAction) {
+            self.onCapture = onCapture
+            self.dismiss = dismiss
+        }
+
+        func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey: Any]) {
+            if let image = info[.originalImage] as? UIImage {
+                onCapture(image)
+            }
+            dismiss()
+        }
+
+        func imagePickerControllerDidCancel(_ picker: UIImagePickerController) {
+            dismiss()
+        }
+    }
+}
+

--- a/Inkwell Keeper/InkwellKeeperApp.swift
+++ b/Inkwell Keeper/InkwellKeeperApp.swift
@@ -41,6 +41,7 @@ struct InkwellKeeperApp: App {
             let c = try ModelContainer(
                 for: CollectedCard.self, CardSet.self, CollectionStats.self,
                 PriceHistory.self, Deck.self, DeckCard.self,
+                CardImageAttachment.self,
                 configurations: config
             )
             print("✅ [ModelContainer] Opened successfully at \(config.url.path)")
@@ -65,6 +66,7 @@ struct InkwellKeeperApp: App {
             let c = try ModelContainer(
                 for: CollectedCard.self, CardSet.self, CollectionStats.self,
                 PriceHistory.self, Deck.self, DeckCard.self,
+                CardImageAttachment.self,
                 configurations: config
             )
             print("✅ [ModelContainer] Recovery successful — fresh store created")

--- a/Inkwell Keeper/Models/SwiftDataModels.swift
+++ b/Inkwell Keeper/Models/SwiftDataModels.swift
@@ -30,6 +30,9 @@ class CollectedCard {
     var uniqueId: String?
     var cardNumber: Int?
 
+    @Relationship(deleteRule: .cascade, inverse: \CardImageAttachment.card)
+    var imageAttachments: [CardImageAttachment]?
+
     var cardRarity: CardRarity {
         get { CardRarity(rawValue: rarity) ?? .common }
         set { rarity = newValue.rawValue }
@@ -146,5 +149,22 @@ class PriceHistory {
         self.price = price
         self.date = Date()
         self.source = source
+    }
+}
+
+@Model
+class CardImageAttachment {
+    @Attribute(.unique) var id: UUID
+    var fileName: String
+    var dateAdded: Date
+
+    @Relationship(deleteRule: .nullify)
+    var card: CollectedCard?
+
+    init(fileName: String, card: CollectedCard) {
+        self.id = UUID()
+        self.fileName = fileName
+        self.dateAdded = Date()
+        self.card = card
     }
 }

--- a/Inkwell Keeper/Services/CardImageStorageService.swift
+++ b/Inkwell Keeper/Services/CardImageStorageService.swift
@@ -1,0 +1,65 @@
+//
+//  CardImageStorageService.swift
+//  Inkwell Keeper
+//
+
+import UIKit
+import Foundation
+
+class CardImageStorageService {
+    static let shared = CardImageStorageService()
+
+    private let fileManager = FileManager.default
+    private let directoryName = "UserCardImages"
+
+    private var storageDirectory: URL {
+        let documentsURL = fileManager.urls(for: .documentDirectory, in: .userDomainMask).first!
+        let directory = documentsURL.appendingPathComponent(directoryName)
+        if !fileManager.fileExists(atPath: directory.path) {
+            try? fileManager.createDirectory(at: directory, withIntermediateDirectories: true)
+        }
+        return directory
+    }
+
+    /// Save a UIImage to disk and return the file name.
+    func saveImage(_ image: UIImage) -> String? {
+        let fileName = UUID().uuidString + ".jpg"
+        let fileURL = storageDirectory.appendingPathComponent(fileName)
+
+        // Compress to JPEG at 85% quality to balance size and quality
+        guard let data = image.jpegData(compressionQuality: 0.85) else { return nil }
+
+        do {
+            try data.write(to: fileURL)
+            return fileName
+        } catch {
+            print("❌ [CardImageStorage] Failed to save image: \(error)")
+            return nil
+        }
+    }
+
+    /// Load a UIImage from disk by file name.
+    func loadImage(fileName: String) -> UIImage? {
+        let fileURL = storageDirectory.appendingPathComponent(fileName)
+        guard let data = try? Data(contentsOf: fileURL) else { return nil }
+        return UIImage(data: data)
+    }
+
+    /// Get the full URL for an image file name.
+    func imageURL(for fileName: String) -> URL {
+        storageDirectory.appendingPathComponent(fileName)
+    }
+
+    /// Delete an image from disk by file name.
+    func deleteImage(fileName: String) {
+        let fileURL = storageDirectory.appendingPathComponent(fileName)
+        try? fileManager.removeItem(at: fileURL)
+    }
+
+    /// Delete multiple images from disk.
+    func deleteImages(fileNames: [String]) {
+        for fileName in fileNames {
+            deleteImage(fileName: fileName)
+        }
+    }
+}

--- a/Inkwell Keeper/ViewModels/CollectionManager.swift
+++ b/Inkwell Keeper/ViewModels/CollectionManager.swift
@@ -13,6 +13,7 @@ import Combine
 class CollectionManager: ObservableObject {
     private var modelContext: ModelContext?
     private let pricingService = PricingService.shared
+    private let imageStorage = CardImageStorageService.shared
 
     @Published var collectedCards: [LorcanaCard] = []
     @Published var wishlistCards: [LorcanaCard] = []
@@ -173,14 +174,17 @@ class CollectionManager: ObservableObject {
     
     func removeCard(_ card: LorcanaCard) {
         guard let context = modelContext else { return }
-        
+
         let descriptor = FetchDescriptor<CollectedCard>(
             predicate: #Predicate<CollectedCard> { $0.cardId == card.id && $0.isWishlisted == false }
         )
-        
+
         do {
             let cardsToDelete = try context.fetch(descriptor)
             for cardData in cardsToDelete {
+                // Clean up attached images from disk
+                let fileNames = (cardData.imageAttachments ?? []).map { $0.fileName }
+                imageStorage.deleteImages(fileNames: fileNames)
                 context.delete(cardData)
             }
             try context.save()
@@ -278,6 +282,8 @@ class CollectionManager: ObservableObject {
             let allCards = try context.fetch(descriptor)
 
             for card in allCards {
+                let fileNames = (card.imageAttachments ?? []).map { $0.fileName }
+                imageStorage.deleteImages(fileNames: fileNames)
                 context.delete(card)
             }
 
@@ -298,10 +304,12 @@ class CollectionManager: ObservableObject {
         guard let context = modelContext else { return }
 
         do {
-            // Delete all CollectedCards (collection and wishlist)
+            // Delete all CollectedCards (collection and wishlist) and their image files
             let collectedDescriptor = FetchDescriptor<CollectedCard>()
             let allCollectedCards = try context.fetch(collectedDescriptor)
             for card in allCollectedCards {
+                let fileNames = (card.imageAttachments ?? []).map { $0.fileName }
+                imageStorage.deleteImages(fileNames: fileNames)
                 context.delete(card)
             }
 
@@ -741,6 +749,42 @@ class CollectionManager: ObservableObject {
         } catch {
             return 0
         }
+    }
+
+    // MARK: - Image Attachments
+
+    func addImageAttachment(to collectedCard: CollectedCard, image: UIImage) -> CardImageAttachment? {
+        guard let context = modelContext else { return nil }
+        guard let fileName = imageStorage.saveImage(image) else { return nil }
+
+        let attachment = CardImageAttachment(fileName: fileName, card: collectedCard)
+        context.insert(attachment)
+
+        do {
+            try context.save()
+            return attachment
+        } catch {
+            print("❌ [addImageAttachment] Error: \(error)")
+            imageStorage.deleteImage(fileName: fileName)
+            return nil
+        }
+    }
+
+    func removeImageAttachment(_ attachment: CardImageAttachment) {
+        guard let context = modelContext else { return }
+
+        imageStorage.deleteImage(fileName: attachment.fileName)
+        context.delete(attachment)
+
+        do {
+            try context.save()
+        } catch {
+            print("❌ [removeImageAttachment] Error: \(error)")
+        }
+    }
+
+    func getImageAttachments(for collectedCard: CollectedCard) -> [CardImageAttachment] {
+        return (collectedCard.imageAttachments ?? []).sorted { $0.dateAdded < $1.dateAdded }
     }
 }
 

--- a/Inkwell Keeper/Views/DetailView.swift
+++ b/Inkwell Keeper/Views/DetailView.swift
@@ -198,6 +198,16 @@ struct CollectionCardDetailView: View {
                             .fill(Color.lorcanaDark.opacity(0.8))
                     )
 
+                    // User card photos section (only for owned cards)
+                    if let collected = collectedCard {
+                        CardImageAttachmentView(collectedCard: collected)
+                            .padding()
+                            .background(
+                                RoundedRectangle(cornerRadius: 16)
+                                    .fill(Color.lorcanaDark.opacity(0.8))
+                            )
+                    }
+
                     // Check Prices section
                     BuyCardOptionsView(card: card)
                         .padding(.horizontal)


### PR DESCRIPTION
Users can now attach photos of their physical cards to collected cards.
Includes camera capture, photo library picker, fullscreen viewer with
pinch-to-zoom, and image management (add/delete). Photos are stored
on disk as JPEGs with metadata tracked via SwiftData. Image files are
automatically cleaned up when cards are removed from the collection.

https://claude.ai/code/session_01UarxRRW34CpNNnz8wCW8rH