### PR TITLE
Add support for Dreamborn bulk/backup import format

### DIFF
--- a/Inkwell Keeper/Services/ImportService.swift
+++ b/Inkwell Keeper/Services/ImportService.swift
@@ -70,7 +70,8 @@ class ImportService {
     enum ImportFormat {
         case csv              // CSV with headers
         case textList         // Simple text list (one per line)
-        case dreamborn        // Dreamborn.ink format
+        case dreamborn        // Dreamborn.ink collection format (Normal,Foil,Name,Set,...)
+        case dreambornBulk    // Dreamborn.ink bulk/backup format (Set Number,Card Number,Variant,Count)
         case lorcanaHQ        // Lorcana HQ format
 
         var description: String {
@@ -78,6 +79,7 @@ class ImportService {
             case .csv: return "CSV File"
             case .textList: return "Text List"
             case .dreamborn: return "Dreamborn.ink"
+            case .dreambornBulk: return "Dreamborn.ink (Backup)"
             case .lorcanaHQ: return "Lorcana HQ"
             }
         }
@@ -116,8 +118,27 @@ class ImportService {
                 }
             }
 
-            // Special handling for Dreamborn format to process both normal and foil quantities
-            if format == .dreamborn {
+            // Special handling for Dreamborn Bulk format (Set Number,Card Number,Variant,Count)
+            if format == .dreambornBulk {
+                if let (setName, cardNumber, variant, quantity) = parseDreambornBulkLine(line) {
+                    // Find card by set name + card number
+                    if let matchedCard = findCardByNumber(cardNumber: cardNumber, setName: setName, variant: variant) {
+                        successful.append(ImportedCard(card: matchedCard, quantity: quantity, originalLine: line))
+                    }
+                    // If non-normal variant not found, try to create it from normal
+                    else if variant != .normal,
+                            let normalCard = findCardByNumber(cardNumber: cardNumber, setName: setName, variant: .normal) {
+                        let variantCard = createVariant(from: normalCard, variant: variant)
+                        successful.append(ImportedCard(card: variantCard, quantity: quantity, originalLine: line))
+                    }
+                    else {
+                        let setInfo = " from set '\(setName)'"
+                        failed.append(FailedImport(originalLine: line, reason: "Card not found: #\(cardNumber)\(setInfo) [\(variant.displayName)]"))
+                    }
+                }
+            }
+            // Special handling for Dreamborn Collection format to process both normal and foil quantities
+            else if format == .dreamborn {
                 // parseDreambornLineRaw returns nil for rows with 0,0 quantities
                 if let (normalQty, foilQty, cardName, setName) = parseDreambornLineRaw(line) {
                     var lineHadSuccess = false
@@ -203,6 +224,8 @@ class ImportService {
             return parseTextListLine(line)
         case .dreamborn:
             return parseDreambornLine(line)
+        case .dreambornBulk:
+            return nil // Handled separately in importFromText
         case .lorcanaHQ:
             return parseLorcanaHQLine(line)
         }
@@ -441,7 +464,70 @@ class ImportService {
         return parseTextListLine(line)
     }
 
+    // Dreamborn Bulk format: Set Number,Card Number,Variant,Count
+    // Example: 4,188,normal,2  or  1,13,foil,1
+    private func parseDreambornBulkLine(_ line: String) -> (setName: String, cardNumber: Int, variant: CardVariant, quantity: Int)? {
+        let components = line.components(separatedBy: ",").map { $0.trimmingCharacters(in: .whitespaces) }
+
+        guard components.count >= 4 else { return nil }
+
+        let setNum = components[0]
+        guard let cardNumber = Int(components[1]) else { return nil }
+        let variant = parseVariant(components[2])
+        let quantity = Int(components[3]) ?? 1
+
+        guard quantity > 0 else { return nil }
+
+        guard let setName = mapDreambornSetNumber(setNum) else { return nil }
+
+        return (setName, cardNumber, variant, quantity)
+    }
+
     // MARK: - Card Matching
+
+    private func findCardByNumber(cardNumber: Int, setName: String, variant: CardVariant) -> LorcanaCard? {
+        let setCards = dataManager.getCardsForSet(setName)
+
+        // Find card with matching card number and variant
+        if let match = setCards.first(where: { $0.cardNumber == cardNumber && $0.variant == variant }) {
+            return match
+        }
+
+        return nil
+    }
+
+    private func createVariant(from card: LorcanaCard, variant: CardVariant) -> LorcanaCard {
+        let variantCode: String
+        switch variant {
+        case .normal: variantCode = "_N_"
+        case .foil: variantCode = "_F_"
+        case .enchanted: variantCode = "_E_"
+        case .promo: variantCode = "_P_"
+        case .borderless: variantCode = "_B_"
+        case .epic: variantCode = "_EP_"
+        case .iconic: variantCode = "_I_"
+        }
+        return LorcanaCard(
+            id: card.id.replacingOccurrences(of: "_N_", with: variantCode),
+            name: card.name,
+            cost: card.cost,
+            type: card.type,
+            rarity: card.rarity,
+            setName: card.setName,
+            cardText: card.cardText,
+            imageUrl: card.imageUrl,
+            price: card.price,
+            variant: variant,
+            cardNumber: card.cardNumber,
+            uniqueId: card.uniqueId,
+            inkwell: card.inkwell,
+            strength: card.strength,
+            willpower: card.willpower,
+            lore: card.lore,
+            franchise: card.franchise,
+            inkColor: card.inkColor
+        )
+    }
 
     private func createFoilVariant(from normalCard: LorcanaCard) -> LorcanaCard {
         // Create a new card with foil variant but same other properties

--- a/Inkwell Keeper/Services/ImportService.swift
+++ b/Inkwell Keeper/Services/ImportService.swift
@@ -426,6 +426,9 @@ class ImportService {
         case "005", "5": return "Shimmering Skies"
         case "006", "6": return "Azurite Sea"
         case "007", "7": return "Archazia's Island"
+        case "008", "8": return "Reign of Jafar"
+        case "009", "9": return "Whispers in the Well"
+        case "010", "10": return "Fabled"
         case "P1": return "Promo" // Promo cards
         case "C1": return "Promo" // Convention promos
         case "D23": return "Promo" // D23 promos
@@ -499,7 +502,7 @@ class ImportService {
             return match
         }
 
-        // Priority 3: Fuzzy match on name (any variant, any set)
+        // Priority 3: Fuzzy match on name with correct variant
         let fuzzyMatches = allCards.filter { card in
             let cardName = normalizeName(card.name)
             return cardName.contains(normalizedName) || normalizedName.contains(cardName)
@@ -509,8 +512,14 @@ class ImportService {
             return bestMatch
         }
 
-        // Priority 4: Return any fuzzy match
-        return fuzzyMatches.first
+        // Priority 4: Return any fuzzy match, but only for normal variant requests
+        // For non-normal variants (foil, enchanted, etc.), returning a wrong-variant
+        // card would prevent the caller from creating the correct variant
+        if variant == .normal {
+            return fuzzyMatches.first
+        }
+
+        return nil
     }
 
     // MARK: - Helper Methods

--- a/Inkwell Keeper/Views/BulkImportView.swift
+++ b/Inkwell Keeper/Views/BulkImportView.swift
@@ -424,18 +424,31 @@ struct BulkImportView: View {
 
     private func detectFormat(from text: String) -> ImportService.ImportFormat {
         let firstLine = text.components(separatedBy: .newlines).first ?? ""
+        let lowerFirstLine = firstLine.lowercased()
 
-        // Check if it's a Dreamborn CSV (has the specific header or comma-separated with numbers at start)
-        if firstLine.lowercased().contains("normal") &&
-           firstLine.lowercased().contains("foil") &&
-           firstLine.lowercased().contains("name") {
+        // Check for Dreamborn Bulk/Backup format: "Set Number,Card Number,Variant,Count"
+        if lowerFirstLine.contains("set number") &&
+           lowerFirstLine.contains("card number") &&
+           lowerFirstLine.contains("variant") &&
+           lowerFirstLine.contains("count") {
+            return .dreambornBulk
+        }
+
+        // Check if it's a Dreamborn Collection CSV (has the specific header)
+        if lowerFirstLine.contains("normal") &&
+           lowerFirstLine.contains("foil") &&
+           lowerFirstLine.contains("name") {
             return .dreamborn
         }
 
-        // Check if any early line looks like Dreamborn format (starts with numbers, has quoted card name)
+        // Check if any early line looks like Dreamborn Bulk format (number,number,variant,number)
         let earlyLines = text.components(separatedBy: .newlines).prefix(5)
         for line in earlyLines where !line.isEmpty {
-            // Pattern: number,number,"Card Name",
+            // Pattern: number,number,variant_word,number (e.g. "4,188,normal,2")
+            if line.range(of: #"^\d+,\d+,(normal|foil|enchanted|promo|borderless),\d+$"#, options: .regularExpression) != nil {
+                return .dreambornBulk
+            }
+            // Pattern: number,number,"Card Name", (Dreamborn Collection without header)
             if line.range(of: #"^\d+,\d+,"[^"]+","#, options: .regularExpression) != nil {
                 return .dreamborn
             }

--- a/Inkwell Keeper/Views/ExportView.swift
+++ b/Inkwell Keeper/Views/ExportView.swift
@@ -855,7 +855,7 @@ struct ExportView: View {
             let setNum2 = getSetNumber(for: second.card.setName)
 
             if setNum1 != setNum2 {
-                return setNum1 < setNum2  // String comparison works fine with 3-digit format
+                return (Int(setNum1) ?? 999) < (Int(setNum2) ?? 999)
             }
             return first.cardNumber < second.cardNumber
         }
@@ -891,18 +891,18 @@ struct ExportView: View {
     }
 
     private func getSetNumber(for setName: String) -> String {
-        // Map set names to Dreamborn set numbers (3-digit format)
+        // Map set names to Dreamborn set numbers (unpadded, matching Dreamborn's format)
         switch setName {
-        case "The First Chapter": return "001"
-        case "Rise of the Floodborn": return "002"
-        case "Into the Inklands": return "003"
-        case "Ursula's Return": return "004"
-        case "Shimmering Skies": return "005"
-        case "Azurite Sea": return "006"
-        case "Archazia's Island": return "007"
-        case "Reign of Jafar": return "008"
-        case "Whispers in the Well": return "009"
-        case "Fabled": return "010"
+        case "The First Chapter": return "1"
+        case "Rise of the Floodborn": return "2"
+        case "Into the Inklands": return "3"
+        case "Ursula's Return": return "4"
+        case "Shimmering Skies": return "5"
+        case "Azurite Sea": return "6"
+        case "Archazia's Island": return "7"
+        case "Reign of Jafar": return "8"
+        case "Whispers in the Well": return "9"
+        case "Fabled": return "10"
         default: return "999"  // Unknown sets
         }
     }
@@ -944,7 +944,7 @@ struct ExportView: View {
             let setNum2 = getSetNumber(for: second.card.setName)
 
             if setNum1 != setNum2 {
-                return setNum1 < setNum2
+                return (Int(setNum1) ?? 999) < (Int(setNum2) ?? 999)
             }
             if let num1 = first.card.cardNumber, let num2 = second.card.cardNumber {
                 return num1 < num2


### PR DESCRIPTION
## Summary
This PR adds support for importing card collections from Dreamborn.ink's bulk/backup export format, which uses a different CSV structure than their collection format. It also includes improvements to set number handling and card variant matching logic.

## Key Changes

- **New Import Format**: Added `dreambornBulk` format to handle Dreamborn.ink backup exports with structure: `Set Number,Card Number,Variant,Count`
  - Includes dedicated parser `parseDreambornBulkLine()` to extract set number, card number, variant, and quantity
  - Implements fallback logic to create variant cards from normal cards when exact variant match isn't found
  
- **Enhanced Card Matching**: 
  - Added `findCardByNumber()` method for precise card lookup by card number and set name
  - Added `createVariant()` method to generate variant cards (foil, enchanted, etc.) from a base card
  - Improved fuzzy matching to prevent returning wrong-variant cards for non-normal variant requests
  
- **Set Number Updates**:
  - Added mappings for new sets: "Reign of Jafar" (8), "Whispers in the Well" (9), "Fabled" (10)
  - Changed set number format from zero-padded (001, 002) to unpadded (1, 2) to match Dreamborn's actual format
  - Updated export sorting to use numeric comparison instead of string comparison for proper set ordering
  
- **Format Detection**: Enhanced `BulkImportView.detectFormat()` to distinguish between:
  - Dreamborn Collection format (with "Normal", "Foil", "Name" headers)
  - Dreamborn Bulk format (with "Set Number", "Card Number", "Variant", "Count" headers)
  - Fallback pattern matching for headerless files

## Implementation Details

- The bulk format parser gracefully handles missing cards by attempting to create variants from normal cards
- Set number mapping uses both padded and unpadded formats for backward compatibility
- Numeric set comparison ensures correct ordering regardless of format variations
- Separate handling paths for collection vs. bulk formats prevent interference between parsing logic

https://claude.ai/code/session_01JyewdyeQuG3wrSvNaHkuoJ