### PR TITLE
Add Lorcana creator outreach target list and personalized drafts

### DIFF
--- a/marketing/3.0/CREATOR_OUTREACH.md
+++ b/marketing/3.0/CREATOR_OUTREACH.md
@@ -1,0 +1,316 @@
+# Ink Well Keeper 3.0 — Creator Outreach Target List & Drafts
+
+Send window: **Jul 13–15, 2026** (per `STRATEGY.md`), ahead of the Attack of the
+Vine street date on Jul 17. Each draft below personalizes the base template
+from `LAUNCH_POSTS.md` §5 for a specific creator. Fill any remaining
+`[brackets]` with a real, recent reference before sending — generic copy gets
+ignored, a specific one ("loved your Stitch decklist breakdown") gets read.
+
+**Before sending:** look up each channel's actual business contact yourself —
+I did not fabricate email addresses. Check the YouTube channel's **About**
+tab ("View email address" / business inquiries), the show's Linktree, or DM
+on the platform they're most active on. Contact details change often enough
+that a stale one here would bounce.
+
+---
+
+## Target list
+
+| Creator | Platform / focus | Where to reach them | Why they fit |
+|---|---|---|---|
+| **Lorcana Goons** | YouTube — metagame breakdowns, market watch, competitive decks (~9K subs) | YouTube About page business email; [@LorcanaGoons](https://twitter.com/LorcanaGoons) on X | Competitive/meta audience — pitch the deck builder + format validation + live pricing angle |
+| **Lorcana Villain** | YouTube — decklist breakdowns, player interviews, gameplay | YouTube About page business email | Same competitive audience as Goons; decklist-heavy content pairs well with QR deck sharing |
+| **Lorcana Lair** (Garrick) | YouTube — video essays, Cross Continental Challenge coverage, product openings | [@TheLorcanaLair](https://www.youtube.com/@TheLorcanaLair) — YouTube About page | Does product openings specifically — best fit for the batch-scan/haul-card pitch |
+| **Lorcana Academy** | YouTube — strategy/how-to content | YouTube About page business email | Teaching-focused audience — deck legality + AI rules assistant angle |
+| **Club Lorcana** (Zan) | Podcast | Show's Linktree / social links | Podcast — ask for a mid-episode mention or show-notes link instead of a demo |
+| **The Lorcana Muses** (Brittany) | Podcast — strategy, theme decks, meta, inclusive community angle | [thelorcanamuses.buzzsprout.com](https://thelorcanamuses.buzzsprout.com/) contact page | Community/inclusivity framing — lead with "free, no ads, community tool" |
+| **The Lorcana Crew** | Podcast | Buzzsprout show page contact link | General Lorcana audience, good for a straightforward mention |
+| **Live Laugh Lorcana** | Podcast — two sisters, collector/community focus | Show's social links | Collector-leaning audience — lead with set completion + collection value, not competitive |
+| **thegamesfinest** | TikTok — quick deck-building tutorials (60-second format) | TikTok DM / bio link | Short-form audience — pitch a 30-second "scan your box" demo clip, not a full review |
+| **Citizens Of Lorcana** | Community creator (Lorcania profile) | Lorcania.com profile / linked socials | Community hub — good for a broader "tool for the community" framing |
+
+Prioritize the top 6–8 rows first (mid-size, most on-topic for box-opening/deck
+content); treat the last two as a stretch batch if time allows before Jul 17.
+
+---
+
+## Personalized drafts
+
+### 1. Lorcana Goons (YouTube — competitive/meta)
+
+**Subject:** `Free deck + pricing tool for Goons viewers — AotV support day one`
+
+```
+Hi there,
+
+I'm Brevin, solo dev of Ink Well Keeper, a free iOS Lorcana app. I've been
+watching your meta breakdowns [reference a recent video/decklist], and with
+Attack of the Vine landing the 17th I thought version 3.0 might be a useful
+mention for your audience:
+
+• Deck builder with Core/Infinity/Casual format legality validation, mana
+  curve, and missing-cards view — plus QR/link deck sharing so viewers can
+  import a decklist you feature with one tap
+• Live market pricing per card and per deck
+• All 242 AotV cards supported day one
+
+No strings — it's free, I'm not asking for a sponsored spot, just hoping it's
+useful to link in a description or mention on stream. Happy to send a Pro
+promo code (AI deck builder + rules assistant) regardless, and I'd love
+feature requests from a channel this deep into the competitive scene.
+
+App Store: https://apps.apple.com/us/app/ink-well-keeper/id6754206379
+
+Thanks for everything you put into the competitive Lorcana scene.
+— Brevin
+```
+
+---
+
+### 2. Lorcana Villain (YouTube — decklists, interviews, gameplay)
+
+**Subject:** `Deck sharing tool for your decklist breakdowns — free, AotV-ready`
+
+```
+Hi [Name],
+
+I'm Brevin — I build Ink Well Keeper, a free iOS Lorcana collection/deck app.
+Your decklist breakdown videos [reference a recent one, e.g. the Stitch
+winning decklists] are exactly the kind of content this could pair well with:
+
+• QR/link deck sharing — a decklist you feature can be imported by a viewer
+  in one tap instead of typed by hand
+• Format legality validation, mana curve, missing-cards view
+• Live pricing so viewers can see what a list actually costs to build
+
+All free, no ads, nothing to buy to use it. If it's useful to link under a
+video, that'd mean a lot — no obligation either way, and I'm happy to send a
+Pro promo code (AI deck builder + rules Q&A) just for trying it.
+
+App Store: https://apps.apple.com/us/app/ink-well-keeper/id6754206379
+
+Thanks for the interviews and breakdowns — appreciate what you make.
+— Brevin
+```
+
+---
+
+### 3. Lorcana Lair (Garrick — video essays, product openings)
+
+**Subject:** `Scan a whole box in minutes — thought of your product-opening videos`
+
+```
+Hi Garrick,
+
+I'm Brevin, solo developer of Ink Well Keeper, a free iOS Lorcana collection
+tracker. I've watched your Cross Continental Challenge coverage and product
+openings [reference a specific one], and with Attack of the Vine hitting the
+17th, I think the new version might genuinely help on camera:
+
+• Batch-scan a whole stack of cards with the phone camera — a full box logged
+  in minutes, with live per-card and total haul value
+• One tap generates a "haul card" image (top pull, count, total value) — a
+  clean end-card for a video or community post
+• All 242 AotV cards supported day one
+
+No strings — it's free and I'm not pitching a sponsorship. If it saves you
+time logging pulls on camera, a mention would mean a lot. Happy to send a Pro
+promo code either way, and I'd love your take on what's missing.
+
+App Store: https://apps.apple.com/us/app/ink-well-keeper/id6754206379
+
+Really appreciate the essays and event coverage you put out.
+— Brevin
+```
+
+---
+
+### 4. Lorcana Academy (YouTube — strategy/how-to)
+
+**Subject:** `Rules assistant + deck legality tool for teaching content`
+
+```
+Hi [Name],
+
+I'm Brevin, the solo dev behind Ink Well Keeper, a free iOS Lorcana app. Your
+how-to content [reference a specific explainer video] is the kind of teaching
+resource newer players search for, and I think a couple of 3.0 features fit
+that audience well:
+
+• Deck format legality validation (Core/Infinity/Casual) with a
+  missing-cards view — good for viewers building their first legal deck
+• An AI rules Q&A assistant (Pro) for "can I do X" questions
+• Free collection tracking with camera scanning for anyone starting out
+
+Everything Lorcana-related is completely free — no ads, data stays on-device.
+No obligation, but if it's useful to mention for new players, I'd appreciate
+it. Happy to send a Pro promo code regardless.
+
+App Store: https://apps.apple.com/us/app/ink-well-keeper/id6754206379
+
+Thanks for helping people learn the game — that content matters a lot.
+— Brevin
+```
+
+---
+
+### 5. Club Lorcana podcast (Zan)
+
+**Subject:** `Free Lorcana app — open to a quick mention on Club Lorcana?`
+
+```
+Hi Zan,
+
+I'm Brevin, solo developer of Ink Well Keeper, a free iOS Lorcana collection
+and deck-building app. I've enjoyed [reference a recent episode topic], and
+with Attack of the Vine landing the 17th, version 3.0 seemed timely to share:
+
+• Camera scanning (including batch-scanning a whole stack) with all 242 AotV
+  cards supported day one
+• Deck builder with format legality validation and QR/link deck sharing
+• Live market pricing and collection value tracking
+
+It's free, no ads, and nothing Lorcana-related is ever paywalled — only two
+AI extras sit behind an optional Pro tier. If it's ever a fit for a quick
+mention or show-notes link, I'd really appreciate it — completely fine if
+not. Happy to send Pro codes for you and any co-hosts either way.
+
+App Store: https://apps.apple.com/us/app/ink-well-keeper/id6754206379
+
+Thanks for the show — it's a great listen for this community.
+— Brevin
+```
+
+---
+
+### 6. The Lorcana Muses (Brittany)
+
+**Subject:** `Free community collection tool — thought of Team Muses`
+
+```
+Hi Brittany,
+
+I'm Brevin, solo dev of Ink Well Keeper, a free iOS Lorcana app. The
+community/inclusivity focus of the Muses and Team Muses is something I
+really respect, and I built this to be a genuinely free tool for that same
+community — so I wanted to put it on your radar ahead of Attack of the Vine:
+
+• Free camera scanning, set completion tracking, and collection value — no
+  ads, data stays on-device
+• Deck builder with format validation and shareable decks
+• All 242 AotV cards supported at launch on the 17th
+
+Only two AI extras sit behind an optional Pro tier — everything else stays
+free in line with Ravensburger's Community Code. No obligation at all, but if
+it feels like a fit for an episode mention or your community links, I'd be
+grateful. Happy to send Pro codes for you and the team regardless.
+
+App Store: https://apps.apple.com/us/app/ink-well-keeper/id6754206379
+
+Thanks for building such a welcoming corner of this community.
+— Brevin
+```
+
+---
+
+### 7. The Lorcana Crew podcast
+
+**Subject:** `Free Lorcana collection/deck app — timed for Attack of the Vine`
+
+```
+Hi [Name],
+
+I'm Brevin, solo developer of Ink Well Keeper, a free iOS Lorcana collection
+tracker and deck builder. With Attack of the Vine landing the 17th, I wanted
+to share version 3.0 in case it's useful to mention on the show:
+
+• Batch camera scanning, set completion tracking, live collection value
+• Deck builder with format legality validation and QR/link sharing
+• All 242 AotV cards supported day one
+
+Free, no ads, data stays on the device. No strings attached — happy to send
+Pro promo codes (AI deck builder + rules assistant) to you and any co-hosts
+whether or not it ends up being a fit for the show.
+
+App Store: https://apps.apple.com/us/app/ink-well-keeper/id6754206379
+
+Thanks for putting the show together for this community.
+— Brevin
+```
+
+---
+
+### 8. Live Laugh Lorcana podcast
+
+**Subject:** `Free collection-tracking app — thought of your listeners`
+
+```
+Hi [Names],
+
+I'm Brevin, solo dev of Ink Well Keeper, a free iOS app for tracking a
+Lorcana collection. Your show comes at this from a collector/community angle
+I think matches the app well, especially with Attack of the Vine landing the
+17th:
+
+• Scan your cards with the camera (even a whole stack at once) and track set
+  completion across all 13 sets plus promos
+• Live market pricing and total collection value
+• NEW: a "haul card" you can generate after a scanning session — a clean
+  image of your pulls to post or share
+
+Free, no ads, your data stays on your device. No obligation, but if it's ever
+worth a mention, I'd really appreciate it — happy to send Pro promo codes
+either way.
+
+App Store: https://apps.apple.com/us/app/ink-well-keeper/id6754206379
+
+Thanks for the show — really enjoy the collector's-eye perspective.
+— Brevin
+```
+
+---
+
+### 9. thegamesfinest (TikTok — short-form deck tutorials)
+
+**DM (short-form, TikTok-native tone):**
+
+```
+Hey! Love your 60-second Lorcana deck-building clips. I built Ink Well
+Keeper, a free iOS app for scanning/tracking a Lorcana collection and
+building decks — thought it might make a good clip for your format: scan a
+stack of cards → collection updates live → done. No pitch beyond that, just
+figured your audience is exactly who'd want to see it. Free on the App Store
+if you want to try it: https://apps.apple.com/us/app/ink-well-keeper/id6754206379
+Happy to send a Pro code either way — appreciate what you make!
+```
+
+---
+
+### 10. Citizens Of Lorcana (community hub)
+
+**DM / message:**
+
+```
+Hi! I'm Brevin, solo developer of Ink Well Keeper, a free iOS Lorcana
+collection tracker and deck builder — camera scanning, set completion,
+live pricing, and deck sharing, with Attack of the Vine supported day one on
+the 17th. Everything Lorcana-related is free, no ads. Would love to be
+considered for the Lorcania creators/resources list if it's a fit, and happy
+to answer any questions or send Pro codes to the community.
+App Store: https://apps.apple.com/us/app/ink-well-keeper/id6754206379
+Thanks for the work you put into the community hub!
+```
+
+---
+
+## Sending checklist
+
+- [ ] Confirm each creator's actual current contact method (About page email,
+      Linktree, DM) — don't guess or reuse an old address
+- [ ] Fill every remaining `[bracket]` with a genuine, specific reference to
+      their content before sending — no genuine reference, no send
+- [ ] Attach a real screenshot or a short demo clip where the platform allows it
+- [ ] Track responses in one place (spreadsheet or note) — who replied, who
+      got a promo code, who posted
+- [ ] Send window Jul 13–15; if a reply comes in after the 17th, still follow
+      up — set-weekend content runs for the following week too


### PR DESCRIPTION
Researched actual Lorcana YouTube/podcast/TikTok creators and drafted personalized outreach emails/DMs for each, building on the generic template in LAUNCH_POSTS.md.